### PR TITLE
feat: create project showcase page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import CGMForm from "./components/cgm/CGMForm";
 import FoodTracking from "./components/FoodTracking";
 import OverallDashboard from "./components/OverallDashboard";
 import AiRecommendations from "./components/AiRecommendations";
+import Showcase from "./components/Showcase";
 
 
 function App() {
@@ -55,6 +56,10 @@ function App() {
         {
           path: "/signup3",
           element: <Signup03 />,
+        },
+        {
+          path: "/showcase",
+          element: <Showcase />,
         },
       ],
     },

--- a/frontend/src/components/Showcase.css
+++ b/frontend/src/components/Showcase.css
@@ -1,0 +1,216 @@
+/* Showcase.css */
+
+/* --- General Styles & Variables --- */
+:root {
+  --primary-color: #3d52a0;
+  --secondary-color: #7091e6;
+  --accent-color: #adbbda;
+  --background-color: #ede8f5;
+  --text-color: #333;
+  --card-background: #ffffff;
+  --footer-background: #333;
+  --footer-text-color: #fff;
+  --font-primary: 'Arial', sans-serif;
+  --font-secondary: 'Georgia', serif;
+}
+
+.showcase {
+  font-family: var(--font-primary);
+  color: var(--text-color);
+  background-color: var(--background-color);
+}
+
+section {
+  padding: 60px 20px;
+  text-align: center;
+}
+
+.section-title {
+  font-family: var(--font-secondary);
+  font-size: 2.5rem;
+  margin-bottom: 40px;
+  color: var(--primary-color);
+}
+
+/* --- Sticky Navigation --- */
+.sticky-nav {
+  position: sticky;
+  top: 0;
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(10px);
+  padding: 15px 0;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.sticky-nav ul {
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+}
+
+.sticky-nav li {
+  margin: 0 20px;
+}
+
+.sticky-nav a {
+  text-decoration: none;
+  color: var(--primary-color);
+  font-weight: bold;
+  transition: color 0.3s;
+}
+
+.sticky-nav a:hover {
+  color: var(--secondary-color);
+}
+
+/* --- Hero Section --- */
+.hero-section {
+  background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+  color: white;
+  padding: 100px 20px;
+  text-align: center;
+}
+
+.hero-content h1 {
+  font-family: var(--font-secondary);
+  font-size: 3.5rem;
+  margin-bottom: 10px;
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  max-width: 600px;
+  margin: 0 auto 30px;
+}
+
+.cta-button {
+  background-color: white;
+  color: var(--primary-color);
+  padding: 15px 30px;
+  border-radius: 50px;
+  text-decoration: none;
+  font-weight: bold;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.cta-button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+}
+
+/* --- Features Section --- */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 30px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.feature-card {
+  background-color: var(--card-background);
+  padding: 30px;
+  border-radius: 10px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.feature-card:hover {
+  transform: translateY(-10px);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.1);
+}
+
+.feature-icon {
+  font-size: 3rem;
+  margin-bottom: 15px;
+}
+
+.feature-card h3 {
+  font-family: var(--font-secondary);
+  font-size: 1.5rem;
+  color: var(--primary-color);
+  margin-bottom: 10px;
+}
+
+/* --- Demo Section --- */
+.video-placeholder {
+  width: 100%;
+  max-width: 800px;
+  aspect-ratio: 16 / 9;
+  background-color: #ddd;
+  margin: 0 auto;
+  border-radius: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.2rem;
+  color: #666;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+/* --- Team Section --- */
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 30px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.team-member-card {
+  background-color: var(--card-background);
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+}
+
+.team-member-photo {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background-color: #ccc;
+  margin: 0 auto 15px;
+}
+
+.team-member-links a {
+  margin: 0 10px;
+  color: var(--secondary-color);
+  text-decoration: none;
+}
+
+.team-member-links a:hover {
+  text-decoration: underline;
+}
+
+/* --- Footer --- */
+.showcase-footer {
+  background-color: var(--footer-background);
+  color: var(--footer-text-color);
+  padding: 40px 20px;
+  text-align: center;
+}
+
+.footer-links a {
+  color: white;
+  text-decoration: none;
+  margin: 0 10px;
+}
+
+.footer-links a:hover {
+  text-decoration: underline;
+}
+
+/* --- Responsiveness --- */
+@media (max-width: 768px) {
+  .hero-content h1 {
+    font-size: 2.5rem;
+  }
+
+  .section-title {
+    font-size: 2rem;
+  }
+}

--- a/frontend/src/components/Showcase.js
+++ b/frontend/src/components/Showcase.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import './Showcase.css';
+
+function Showcase() {
+  return (
+    <div className="showcase">
+      {/* Sticky Navigation */}
+      <nav className="sticky-nav">
+        <ul>
+          <li><a href="#features">Features</a></li>
+          <li><a href="#demo">Demo</a></li>
+          <li><a href="#team">Team</a></li>
+        </ul>
+      </nav>
+
+      {/* Hero Section */}
+      <section className="hero-section">
+        <div className="hero-content">
+          <h1>DiaBite: Smart Diabetes Management</h1>
+          <p className="hero-subtitle">
+            An intuitive platform to track, analyze, and manage diabetes with AI-powered insights.
+          </p>
+          <a href="#demo" className="cta-button">Watch Demo</a>
+        </div>
+      </section>
+
+      {/* Features Section */}
+      <section id="features" className="features-section">
+        <h2 className="section-title">Key Features</h2>
+        <div className="features-grid">
+          {/* Feature 1 */}
+          <div className="feature-card">
+            <div className="feature-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 20V10M18 20V4M6 20V16"/></svg>
+            </div>
+            <h3>Dashboard</h3>
+            <p>A comprehensive overview of your health metrics.</p>
+          </div>
+          {/* Feature 2 */}
+          <div className="feature-card">
+            <div className="feature-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 6v12m6-6H6"/></svg>
+            </div>
+            <h3>Food Tracking</h3>
+            <p>Log your meals and get instant nutritional feedback.</p>
+          </div>
+          {/* Feature 3 */}
+          <div className="feature-card">
+            <div className="feature-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 8V4m0 16v-4m8-8h-4m-8 0H4m16 8v-2m-4-2h-2m-4 0H8m-2-2v-2m4 4h2m0 4v2m-4-2h-2m-2-2H4"/></svg>
+            </div>
+            <h3>AI Recommendations</h3>
+            <p>Personalized suggestions to improve your health.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Demo Section */}
+      <section id="demo" className="demo-section">
+        <h2 className="section-title">Project Demo</h2>
+        <div className="video-container">
+          {/* In a real project, you would replace this with an embedded video */}
+          <div className="video-placeholder">
+            <p>Video demo coming soon!</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Team Section */}
+      <section id="team" className="team-section">
+        <h2 className="section-title">Meet the Team</h2>
+        <div className="team-grid">
+          {/* Team Member 1 */}
+          <div className="team-member-card">
+            <div className="team-member-photo"></div>
+            <h3>T. Hemanth</h3>
+            <p>Project coordination, Backend development, AI integration</p>
+          </div>
+          {/* Team Member 2 */}
+          <div className="team-member-card">
+            <div className="team-member-photo"></div>
+            <h3>N. Sanjay</h3>
+            <p>UI/UX design, AI recommendation system implementation</p>
+          </div>
+          {/* Team Member 3 */}
+          <div className="team-member-card">
+            <div className="team-member-photo"></div>
+            <h3>P. Nikhita</h3>
+            <p>Documentation, quality assurance</p>
+          </div>
+          {/* Team Member 4 */}
+          <div className="team-member-card">
+            <div className="team-member-photo"></div>
+            <h3>P. Jithamanyu</h3>
+            <p>UI/UX design, frontend development</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="showcase-footer">
+        <p>&copy; 2024 DiaBite. All rights reserved.</p>
+        <div className="footer-links">
+          <a href="https://github.com/your-repo/diabite" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export default Showcase;


### PR DESCRIPTION
This commit introduces a new project showcase page for DiaBite.

The page is designed to be a modern and visually appealing showcase for the project, aimed at recruiters, mentors, and developers. It includes the following sections:
- A compelling hero section with a call-to-action.
- A grid of key features with SVG icons.
- A placeholder for a project demo video.
- A section to highlight the team members and their roles.
- A sticky navigation bar for easy scrolling.
- A clean footer with a link to the project repository.

The page is built as a new React component (`Showcase.js`) and is accessible at the `/showcase` route. The styling is self-contained in `Showcase.css` and is fully responsive.